### PR TITLE
/metadata.json を用意した

### DIFF
--- a/lib/togostanza/application.rb
+++ b/lib/togostanza/application.rb
@@ -25,6 +25,14 @@ module TogoStanza
       haml :index
     end
 
+    get '/metadata.json' do
+      metadata = Stanza.all.map {|stanza|
+        stanza.new.metadata
+      }.compact
+
+      json metadata
+    end
+
     get '/:id.json' do |id|
       json Stanza.find(id).new(params).context
     end

--- a/lib/togostanza/application.rb
+++ b/lib/togostanza/application.rb
@@ -26,9 +26,12 @@ module TogoStanza
     end
 
     get '/metadata.json' do
-      metadata = Stanza.all.map {|stanza|
-        stanza.new.metadata
-      }.compact
+      metadata = {
+        "@context" => {
+          stanza: "http://togostanza.org/resource/stanza#"
+        },
+        "stanza:stanzas" => Stanza.all.map {|stanza| stanza.new.metadata }.compact
+      }
 
       json metadata
     end

--- a/lib/togostanza/stanza/base.rb
+++ b/lib/togostanza/stanza/base.rb
@@ -225,7 +225,11 @@ module TogoStanza::Stanza
     def metadata
       path = File.join(root, 'metadata.json')
 
-      JSON.load(open(path))
+      if File.exist?(path)
+        JSON.load(open(path))
+      else
+        nil
+      end
     end
   end
 end

--- a/spec/dummy/foo_stanza/metadata.json
+++ b/spec/dummy/foo_stanza/metadata.json
@@ -1,11 +1,8 @@
 {
-  "@context": {
-    "stanza": "http://togostanza.org/resource/stanza#"
-  },
   "@id": "http://togogenome.org/stanza/foo",
   "stanza:label": "Foo Stanza",
   "stanza:definition": "This is Foo Stanza.",
-  "stanza:parameters": [
+  "stanza:parameter": [
     { "stanza:key": "name",
       "stanza:example": "alice",
       "stanza:description": "Name",
@@ -13,13 +10,15 @@
     }
   ],
   "stanza:usage": "<div data-stanza=\"http://togogenome.org/stanza/foo\" data-stanza-name=\"alice\"></div>",
-  "stanza:type": "stanza:Stanza",
-  "stanza:context": "",
-  "stanza:display": "",
-  "stanza:provider": "provider of this stanza",
+  "stanza:type": "Stanza",
+  "stanza:context": "Gene",
+  "stanza:display": "Table",
+  "stanza:provider": "DBCLS",
   "stanza:license": "CC-BY",
   "stanza:author": "author name",
   "stanza:address": "name@example.org",
+  "stanza:contributor": [ "Taro Stanza", "Hanako Stanza" ],
+  "stanza:version": "1",
   "stanza:created": "2015-02-27",
   "stanza:updated": "2015-02-27"
 }

--- a/spec/features/metadata_spec.rb
+++ b/spec/features/metadata_spec.rb
@@ -12,8 +12,8 @@ describe 'Metadata' do
     it 'should return metadata as JSON' do
       json = JSON.parse(page.body)
 
-      json.class.should eq(Array)
-      json.first.should include('stanza:label' => 'Foo Stanza')
+      json["stanza:stanzas"].class.should eq(Array)
+      json["stanza:stanzas"].first.should include('stanza:label' => 'Foo Stanza')
     end
   end
 

--- a/spec/features/metadata_spec.rb
+++ b/spec/features/metadata_spec.rb
@@ -1,10 +1,31 @@
 require 'spec_helper'
 
 describe 'Metadata' do
-  it 'should return metadata as JSON' do
-    visit '/foo/metadata.json'
+  describe '/metadata.json' do
+    before do
+      # 実行順により base_spec で作られた Classオブジェクトが返って来て意図通りのテストにならないため
+      allow(TogoStanza::Stanza).to receive(:all).and_return([BarStanza, FooStanza])
 
-    json = JSON.parse(page.body)
-    json.should include('stanza:label' => 'Foo Stanza')
+      visit '/metadata.json'
+    end
+
+    it 'should return metadata as JSON' do
+      json = JSON.parse(page.body)
+
+      json.class.should eq(Array)
+      json.first.should include('stanza:label' => 'Foo Stanza')
+    end
+  end
+
+  describe '/:id/metadata.json' do
+    before do
+      visit '/foo/metadata.json'
+    end
+
+    it 'should return metadata as JSON' do
+      json = JSON.parse(page.body)
+
+      json.should include('stanza:label' => 'Foo Stanza')
+    end
   end
 end


### PR DESCRIPTION
/metadata.json でプロバイダー配下の全スタンザのメタデータを1ファイルの json で返します。
WIP を取るには、別途で検討中のJSONの形式に沿う形に出力を変更する必要あり。