### PR TITLE
gemspec では metadata.json の内容を参照するようにした

### DIFF
--- a/lib/togostanza/cli.rb
+++ b/lib/togostanza/cli.rb
@@ -220,7 +220,7 @@ module TogoStanza
         File.expand_path('../../../templates/stanza', __FILE__)
       end
 
-      def replace_author
+      def replace_address
         gsub_file("#{template_dir}/metadata.json.erb", /address":\s".*"/, "address\": \"#{addr}\"")
       end
     end

--- a/lib/togostanza/cli.rb
+++ b/lib/togostanza/cli.rb
@@ -207,7 +207,6 @@ module TogoStanza
       end
 
       def replace_author
-        gsub_file("#{template_dir}/gemspec.erb", /spec.authors\s*=\s\[\'.*\'\]/, "spec.authors       = ['#{name}']")
         gsub_file("#{template_dir}/metadata.json.erb", /author":\s".*"/, "author\": \"#{name}\"")
       end
     end
@@ -222,7 +221,6 @@ module TogoStanza
       end
 
       def replace_author
-        gsub_file("#{template_dir}/gemspec.erb", /spec.email\s*=\s\[\'.*\'\]/, "spec.email         = ['#{addr}']")
         gsub_file("#{template_dir}/metadata.json.erb", /address":\s".*"/, "address\": \"#{addr}\"")
       end
     end

--- a/templates/stanza/gemspec.erb
+++ b/templates/stanza/gemspec.erb
@@ -1,15 +1,20 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
+require 'json'
+metadata = open('./metadata.json') do |io|
+  JSON.load(io)
+end
+
 Gem::Specification.new do |spec|
   spec.name          = '<%= file_name %>'
   spec.version       = '0.0.1'
-  spec.authors       = ['TODO: Write your name']
-  spec.email         = ['TODO: Write your email address']
-  spec.summary       = %q{Data visualization, analysis and searching tool for semantic web.}
-  spec.description   = %q{<%= file_name %>.}
+  spec.authors       = Array(metadata["stanza:author"])
+  spec.email         = Array(metadata["stanza:address"])
+  spec.summary       = metadata["stanza:label"]
+  spec.description   = metadata["stanza:definition"]
   spec.homepage      = ''
-  spec.license       = 'MIT'
+  spec.license       = metadata["stanza:license"]
 
   spec.files         = Dir.glob('**/*')
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }

--- a/templates/stanza/metadata.json.erb
+++ b/templates/stanza/metadata.json.erb
@@ -12,7 +12,7 @@
   "stanza:license": "",
   "stanza:author": "author name",
   "stanza:address": "name@example.org",
-  "stanza:contributor": [ "Taro Stanza", "Hanako Stanza" ],
+  "stanza:contributor": [],
   "stanza:created": "<%= Date.today %>",
   "stanza:updated": "<%= Date.today %>"
 }


### PR DESCRIPTION
gemspec の内容は、metadata.json から取るという方針になったため、
togostanza(gem) の generator で生成する gemspec (テンプレート) も変更した。

基本的に metadata.json を正としそちらのみ変更し反映するようにするため、
`togostanza name` コマンド , `togostanza mail` コマンドでは、
gemspec のテンプレートは変えないようにした

ref) https://github.com/togostanza/togostanza/pull/44