### PR TITLE
SPARQLを別ファイル(handlebars)で管理できるようにする

### DIFF
--- a/lib/togostanza/cli.rb
+++ b/lib/togostanza/cli.rb
@@ -48,6 +48,7 @@ module TogoStanza
         template 'template.hbs.erb',  "#{file_name}/template.hbs"
         template 'metadata.json.erb', "#{file_name}/metadata.json"
 
+        create_file "#{file_name}/sparql/.keep"
         create_file "#{file_name}/assets/#{stanza_id}/.keep"
       end
 

--- a/lib/togostanza/stanza/querying.rb
+++ b/lib/togostanza/stanza/querying.rb
@@ -3,9 +3,7 @@ require 'sparql/client'
 module TogoStanza::Stanza
   module Querying
     MAPPINGS = {
-      togogenome: 'http://ep.dbcls.jp/sparql7',
-      uniprot:    'http://ep.dbcls.jp/sparql7',
-      go:         'http://ep.dbcls.jp/sparql7'
+      togogenome: 'http://togogenome.org/sparql'
     }
 
     def query(endpoint, sparql)

--- a/lib/togostanza/stanza/querying.rb
+++ b/lib/togostanza/stanza/querying.rb
@@ -1,4 +1,5 @@
 require 'sparql/client'
+require 'flavour_saver'
 
 module TogoStanza::Stanza
   module Querying
@@ -6,12 +7,19 @@ module TogoStanza::Stanza
       togogenome: 'http://togogenome.org/sparql'
     }
 
-    def query(endpoint, sparql)
+    def query(endpoint, text_or_filename)
+      path = File.join(root, 'sparql', text_or_filename)
+
+      if File.exist?(path)
+        data = OpenStruct.new params
+        text_or_filename = Tilt.new(path).render(data)
+      end
+
       client = SPARQL::Client.new(MAPPINGS[endpoint] || endpoint)
 
       #Rails.logger.debug "SPARQL QUERY: \n#{sparql}"
 
-      client.query(sparql).map {|binding|
+      client.query(text_or_filename).map {|binding|
         binding.each_with_object({}) {|(name, term), hash|
           hash[name] = term.to_s
         }

--- a/lib/togostanza/stanza/querying.rb
+++ b/lib/togostanza/stanza/querying.rb
@@ -17,25 +17,5 @@ module TogoStanza::Stanza
         }
       }
     end
-
-    def uniprot_url_from_togogenome(gene_id)
-      # refseq の UniProt
-      # slr1311 の時 "http://purl.uniprot.org/refseq/NP_439906.1"
-      query(:togogenome, <<-SPARQL).first[:up]
-      PREFIX insdc: <http://insdc.org/owl/>
-      PREFIX idorg: <http://rdf.identifiers.org/database/>
-
-      SELECT DISTINCT ?up
-      FROM <http://togogenome.org/graph/refseq/>
-      WHERE {
-          ?s insdc:feature_locus_tag "#{gene_id}" .
-          ?s rdfs:seeAlso ?np .
-          ?s rdfs:seeAlso ?xref .
-          ?np rdf:type idorg:Protein .
-          BIND (STRAFTER(STR(?np), "ncbiprotein/") AS ?npid)
-          BIND (IRI(CONCAT("http://purl.uniprot.org/refseq/", ?npid)) AS ?up)
-      }
-      SPARQL
-    end
   end
 end


### PR DESCRIPTION
`sparql.hbs` ファイルに 予めSPAQLE を記述しておき、利用できるようにした。

具体的には `query` メソッドを第2引数無しで呼んだ場合は、`sparql.hbs` の中身を実行。
現在の第2引数で SPARQL 文字列を渡した場合の、そのクエリーを実行する機能も残す。