### PR TITLE
API /metadata.json の仕様変更

### DIFF
--- a/lib/togostanza/application.rb
+++ b/lib/togostanza/application.rb
@@ -21,6 +21,10 @@ module TogoStanza
       end
     end
 
+    before do
+      @server_url = request.url.gsub(request.path_info, '')
+    end
+
     get '/' do
       haml :index
     end
@@ -30,7 +34,7 @@ module TogoStanza
         "@context" => {
           stanza: "http://togostanza.org/resource/stanza#"
         },
-        "stanza:stanzas" => Stanza.all.map {|stanza| stanza.new.metadata }.compact
+        "stanza:stanzas" => Stanza.all.map {|stanza| stanza.new.metadata(@server_url) }.compact
       }
 
       json metadata
@@ -53,13 +57,13 @@ module TogoStanza
     get '/:id/help' do |id|
       stanza = Stanza.find(id).new
 
-      haml :help, locals: {stanza: stanza.metadata}
+      haml :help, locals: {stanza: stanza.metadata(@server_url)}
     end
 
     get '/:id/metadata.json' do |id|
       @stanza = Stanza.find(id).new
 
-      json @stanza.metadata
+      json @stanza.metadata(@server_url)
     end
   end
 end

--- a/spec/dummy/foo_stanza/metadata.json
+++ b/spec/dummy/foo_stanza/metadata.json
@@ -1,24 +1,23 @@
 {
-  "@id": "http://togogenome.org/stanza/foo",
-  "stanza:label": "Foo Stanza",
-  "stanza:definition": "This is Foo Stanza.",
-  "stanza:parameter": [
-    { "stanza:key": "name",
-      "stanza:example": "alice",
-      "stanza:description": "Name",
-      "stanza:required": true
+  "id": "foo",
+  "label": "Foo Stanza",
+  "definition": "This is Foo Stanza.",
+  "parameter": [
+    { "key": "name",
+      "example": "alice",
+      "description": "Name",
+      "required": true
     }
   ],
-  "stanza:usage": "<div data-stanza=\"http://togogenome.org/stanza/foo\" data-stanza-name=\"alice\"></div>",
-  "stanza:type": "Stanza",
-  "stanza:context": "Gene",
-  "stanza:display": "Table",
-  "stanza:provider": "DBCLS",
-  "stanza:license": "CC-BY",
-  "stanza:author": "author name",
-  "stanza:address": "name@example.org",
-  "stanza:contributor": [ "Taro Stanza", "Hanako Stanza" ],
-  "stanza:version": "1",
-  "stanza:created": "2015-02-27",
-  "stanza:updated": "2015-02-27"
+  "type": "Stanza",
+  "context": "Gene",
+  "display": "Table",
+  "provider": "DBCLS",
+  "license": "CC-BY",
+  "author": "author name",
+  "address": "name@example.org",
+  "contributor": [ "Taro Stanza", "Hanako Stanza" ],
+  "version": "1",
+  "created": "2015-02-27",
+  "updated": "2015-02-27"
 }

--- a/spec/features/metadata_spec.rb
+++ b/spec/features/metadata_spec.rb
@@ -26,6 +26,7 @@ describe 'Metadata' do
       json = JSON.parse(page.body)
 
       json.should include('stanza:label' => 'Foo Stanza')
+      json.should include('@id' => "http://www.example.com/foo")
     end
   end
 end

--- a/templates/stanza/metadata.json.erb
+++ b/templates/stanza/metadata.json.erb
@@ -1,18 +1,23 @@
 {
-  "@id": "http://togogenome.org/stanza/<%= stanza_id %>",
-  "stanza:label": "",
-  "stanza:definition": "",
-  "stanza:parameter": [
+  "id": "<%= stanza_id %>",
+  "label": "",
+  "definition": "",
+  "parameter": [
+    {
+      "key": "",
+      "example": "",
+      "description": "",
+      "required": true
+    }
   ],
-  "stanza:usage": "<div data-stanza=\"http://togogenome.org/stanza/<%= stanza_id %>\"></div>",
-  "stanza:type": "Stanza",
-  "stanza:context": "",
-  "stanza:display": "",
-  "stanza:provider": "provider of this stanza",
-  "stanza:license": "",
-  "stanza:author": "author name",
-  "stanza:address": "name@example.org",
-  "stanza:contributor": [],
-  "stanza:created": "<%= Date.today %>",
-  "stanza:updated": "<%= Date.today %>"
+  "type": "Stanza",
+  "context": "",
+  "display": "",
+  "provider": "provider of this stanza",
+  "license": "",
+  "author": "author name",
+  "address": "name@example.org",
+  "contributor": [],
+  "created": "<%= Date.today %>",
+  "updated": "<%= Date.today %>"
 }

--- a/togostanza.gemspec
+++ b/togostanza.gemspec
@@ -27,12 +27,12 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'sprockets', '~> 3.4'
   spec.add_runtime_dependency 'thor', '~> 0.19'
 
-  spec.add_development_dependency 'appraisal', '~> 0'
-  spec.add_development_dependency 'bundler', '~> 0'
-  spec.add_development_dependency 'capybara', '~> 0'
-  spec.add_development_dependency 'rake', '~> 0'
-  spec.add_development_dependency 'rspec', '~> 0'
-  spec.add_development_dependency 'rspec-its', '~> 0'
+  spec.add_development_dependency 'appraisal', '~> 0.5'
+  spec.add_development_dependency 'bundler', '~> 1.10'
+  spec.add_development_dependency 'capybara', '~> 2.2'
+  spec.add_development_dependency 'rake', '~> 0.9'
+  spec.add_development_dependency 'rspec', '~> 3.3'
+  spec.add_development_dependency 'rspec-its', '~> 1.2'
 
   spec.required_ruby_version = '>= 1.9.3'
 end


### PR DESCRIPTION
以下の方針に変更したため、API で metadata.json を変更する仕組みを入れた
- スタンザ開発者が用意する metdata.json からは "stanza:" プレフィックスを記述しないようし、API で付けるようにした
- スタンザ開発者が用意する metdata.json では "usage" は記述しなくても、"parameter" の値から構築するようにした
- スタンザ開発者が用意する metdata.json からは URI を記述していた "`@id`" を無くし、"id" でスタンザのIDを記述してもらい、起動している自身のドメインから "`@id`" を構築するようにした