### PR TITLE
Force to use HTTP GET instead of POST to support Wikidata SPARQL endpoint

### DIFF
--- a/lib/togostanza/stanza/querying.rb
+++ b/lib/togostanza/stanza/querying.rb
@@ -15,7 +15,7 @@ module TogoStanza::Stanza
         text_or_filename = Tilt.new(path).render(data)
       end
 
-      client = SPARQL::Client.new(MAPPINGS[endpoint] || endpoint)
+      client = SPARQL::Client.new(MAPPINGS[endpoint] || endpoint, :method => "get")
 
       #Rails.logger.debug "SPARQL QUERY: \n#{sparql}"
 


### PR DESCRIPTION
According to the manual (https://www.mediawiki.org/wiki/Wikidata_query_service/User_Manual), Wikidata SPARQL endpoint doesn't accept POST (403 Forbidden), so set default to GET