### PR TITLE
fix a bug. http session laek

### DIFF
--- a/lib/togostanza/stanza/querying.rb
+++ b/lib/togostanza/stanza/querying.rb
@@ -17,11 +17,13 @@ module TogoStanza::Stanza
 
       client = SPARQL::Client.new(MAPPINGS[endpoint] || endpoint, method: 'get')
 
-      client.query(text_or_filename, **{content_type: 'application/sparql-results+json'}.merge(options)).map {|binding|
+      result = client.query(text_or_filename, **{content_type: 'application/sparql-results+json'}.merge(options)).map {|binding|
         binding.each_with_object({}) {|(name, term), hash|
           hash[name] = term.to_s
         }
       }
+      client.close
+      result
     end
   end
 end


### PR DESCRIPTION
Added code to close the connection explicitly because the dependent library 'sparql-client' had a bug that it did not release the http connection.
https://github.com/ruby-rdf/sparql-client/issues/86